### PR TITLE
Fix readline import

### DIFF
--- a/packages/signer-cli/src/cmdSubmit.ts
+++ b/packages/signer-cli/src/cmdSubmit.ts
@@ -6,7 +6,7 @@ import { Signer, SignerResult } from '@polkadot/api/types';
 import { SignerOptions } from '@polkadot/api/submittable/types';
 import { SignerPayloadRaw } from '@polkadot/types/types';
 
-import readline from 'readline';
+import * as readline from 'readline';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { assert } from '@polkadot/util';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.7.4", "@babel/core@^7.7.5":
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.7.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.5.tgz#ae1323cd035b5160293307f50647e83f8ba62f7e"
   integrity sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==


### PR DESCRIPTION
With the import as `import readline from 'readline';` the signer was not waiting for a signature.