### PR TITLE
Add a --sudo flag to api-cli

### DIFF
--- a/packages/api-cli/README.md
+++ b/packages/api-cli/README.md
@@ -30,7 +30,22 @@ To make a transfer from Alice to Bob, the following can be used -
 yarn run:api tx.balances.transfer 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty 12345 --seed "//Alice"
 ```
 
-If you are installing it globally -
+### Sudo
+
+Some transactions require superuser access. For example, to change the runtime code, you can do
+
+```
+yarn run:api --sudo tx.system.setCode $(xxd -p test.wasm | tr -d $'\n' | xargs printf '0x%s')
+```
+
+Unpacking that command line:
+
+- `--sudo`: don't use normal authentication, but instead get the superuser authentication from the test keyring and upgrade the following transaction
+- `xxd -p test.wasm`: convert the file `test.wasm` into hexadecimal
+- `tr -d $'\n'`: remove newlines from the hexadecimal blob
+- `xargs printf '0x%s'`: insert a leading '0x' onto the front of the blob
+
+## Global Installation
 
 ```
 $ yarn global add @polkadot/api-cli

--- a/packages/api-cli/README.md
+++ b/packages/api-cli/README.md
@@ -35,15 +35,18 @@ yarn run:api tx.balances.transfer 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694
 Some transactions require superuser access. For example, to change the runtime code, you can do
 
 ```
-yarn run:api --sudo tx.system.setCode $(xxd -p test.wasm | tr -d $'\n' | xargs printf '0x%s')
+yarn run:api --sudo --seed "//Alice" tx.system.setCode $(xxd -p test.wasm | tr -d $'\n' | xargs printf '0x%s')
 ```
 
 Unpacking that command line:
 
 - `--sudo`: don't use normal authentication, but instead get the superuser authentication from the test keyring and upgrade the following transaction
+- `--seed "//Alice"`: attempt to use the Alice key as the superuser.
 - `xxd -p test.wasm`: convert the file `test.wasm` into hexadecimal
 - `tr -d $'\n'`: remove newlines from the hexadecimal blob
 - `xargs printf '0x%s'`: insert a leading '0x' onto the front of the blob
+
+In all cases when sudoing, the seed provided should be that of the superuser. For most development nets, that is `"//Alice"`.
 
 ## Global Installation
 

--- a/packages/api-cli/src/api.ts
+++ b/packages/api-cli/src/api.ts
@@ -116,7 +116,7 @@ const {
       required: true
     },
     sudo: {
-      description: 'Run this tx as superuser. Uses dev keyring.',
+      description: 'Run this tx as a wrapped sudo.sudo call',
       type: 'boolean'
     }
   })

--- a/packages/api-cli/src/api.ts
+++ b/packages/api-cli/src/api.ts
@@ -216,7 +216,7 @@ async function makeTx ({ fn, log }: CallInfo): Promise<void> {
     if (result.isInBlock || result.isFinalized) {
       process.exit(0);
     }
-  });
+  }) as Promise<void>;
 }
 
 // make a derive, query or rpc call


### PR DESCRIPTION
Suggested in the comments to #100, this enables CLI users to send
transactions which require superuser authentication. Permission-
raising code adapted from https://polkadot.js.org/api/examples/promise/10_upgrade_chain/.

There's a bit of duck-typing added in `makeTx`, largely because it was
very unclear what interfaces are actually appropriate for `signable`
and `auth`. `ApiCallResult` doesn't work for both code branches.
Additionally, casting `fn(...params) as unknown as Proposal` feels
like it may not be the best possible approach, though it's not clear
what a better one would be.