### PR TITLE
Add magic syntax to api-cli to treat a param as a file and handle it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.10.0-beta.x
 
+- Add support for file syntax for tx params (`@path`) to api-cli (Thanks to https://github.com/coriolinus)
 - Add support for sudo txs (via `--sudo`) to api-cli (Thanks to https://github.com/coriolinus)
 - Cleanup global install docs with correct argument order (Thanks to https://github.com/coriolinus)
 - Allow passing signer tx params in file (Thanks to https://github.com/kwingram25)

--- a/packages/api-cli/README.md
+++ b/packages/api-cli/README.md
@@ -30,21 +30,19 @@ To make a transfer from Alice to Bob, the following can be used -
 yarn run:api tx.balances.transfer 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty 12345 --seed "//Alice"
 ```
 
+### Files as Parameters
+
+It is often desirable to include large binary blobs as transaction parameters. These blobs are often already present in the local filesystem. Therefore, the CLI has special syntax to make life easier: any transaction parameter whose initial character is `@` is treated as a path to a binary file; its contents are automatically converted into appropriate hex form before sending the tx.
+
+The `sudo` example demonstrates this.
+
 ### Sudo
 
 Some transactions require superuser access. For example, to change the runtime code, you can do
 
 ```
-yarn run:api --sudo --seed "//Alice" tx.system.setCode $(xxd -p test.wasm | tr -d $'\n' | xargs printf '0x%s')
+yarn run:api --sudo --seed "//Alice" tx.system.setCode @test.wasm
 ```
-
-Unpacking that command line:
-
-- `--sudo`: don't use normal authentication, but instead get the superuser authentication from the test keyring and upgrade the following transaction
-- `--seed "//Alice"`: attempt to use the Alice key as the superuser.
-- `xxd -p test.wasm`: convert the file `test.wasm` into hexadecimal
-- `tr -d $'\n'`: remove newlines from the hexadecimal blob
-- `xargs printf '0x%s'`: insert a leading '0x' onto the front of the blob
 
 In all cases when sudoing, the seed provided should be that of the superuser. For most development nets, that is `"//Alice"`.
 

--- a/packages/api-cli/src/api.ts
+++ b/packages/api-cli/src/api.ts
@@ -139,6 +139,18 @@ if (paramsFile) {
   params = paramsInline;
 }
 
+// a parameter whose initial character is @ treated as a path and replaced
+// with the hexadecimal representation of the binary contents of that file
+params = params.map(param => {
+  if (param.startsWith('@')) {
+    const path = param.substring(1);
+    assert(fs.existsSync(path), `Cannot find path ${path}`);
+    const data = fs.readFileSync(path).toString('hex');
+    return `0x${data}`;
+  }
+  return param;
+});
+
 // parse the arguments and retrieve the details of what we want to do
 async function getCallInfo (): Promise<CallInfo> {
   assert(endpoint && endpoint.includes('.'), 'You need to specify the command to execute, e.g. query.system.account');


### PR DESCRIPTION
Closes #104.

The leading `@` syntax was chosen because it doesn't conflict with
any standard bash syntax, should be familiar from TS imports, and
should not conflict with any normal operation which a user wants to
do with their transaction. No escapes were therefore implemented.