### PR TITLE
bugfix: handle magic filename expansion before JSON parsing

### DIFF
--- a/packages/api-cli/src/api.ts
+++ b/packages/api-cli/src/api.ts
@@ -77,6 +77,20 @@ const {
 } = yargs
   .command('$0', usage)
   .middleware((argv) => {
+    // a parameter whose initial character is @ treated as a path and replaced
+    // with the hexadecimal representation of the binary contents of that file
+    argv._ = argv._.map((param) => {
+      if (param.startsWith('@')) {
+        const path = param.substring(1);
+        assert(fs.existsSync(path), `Cannot find path ${path}`);
+        const data = fs.readFileSync(path).toString('hex');
+        return `0x${data}`;
+      }
+      return param;
+    });
+    return argv;
+  })
+  .middleware((argv) => {
     argv._ = argv._.map((param) => {
       try {
         return JSON.parse(param);
@@ -138,18 +152,6 @@ if (paramsFile) {
 } else {
   params = paramsInline;
 }
-
-// a parameter whose initial character is @ treated as a path and replaced
-// with the hexadecimal representation of the binary contents of that file
-params = params.map(param => {
-  if (param.startsWith('@')) {
-    const path = param.substring(1);
-    assert(fs.existsSync(path), `Cannot find path ${path}`);
-    const data = fs.readFileSync(path).toString('hex');
-    return `0x${data}`;
-  }
-  return param;
-});
 
 // parse the arguments and retrieve the details of what we want to do
 async function getCallInfo (): Promise<CallInfo> {


### PR DESCRIPTION
Encountered an odd bug when using the filename expansion:

```
  if (param.startsWith('@')) {
            ^

TypeError: param.startsWith is not a function
    at /usr/local/share/.config/yarn/global/node_modules/@polkadot/api-cli/api.js:93:13
```

Given the type of the variable, that should be impossible:
https://github.com/polkadot-js/tools/blob/2fce4a20407c183edfb249df2a2d496121e938d5/packages/api-cli/src/api.ts#L127

The problem ended up being the yargs middleware which speculatively
parsed JSON in the parameters:
https://github.com/polkadot-js/tools/blob/2fce4a20407c183edfb249df2a2d496121e938d5/packages/api-cli/src/api.ts#L79-L88

This was changing the types of the inputs if something was JSON-parseable,
so the actual type of `params` was `any[]`, not `string[]`. Typescript's type
inference engine apparently doesn't catch this kind of problem.

The solution in this PR just moves the filename loading code so
it happens before JSON parsing. This has the side benefit of fixing
a potential bug that nobody's yet noticed: people can put numbers
or JSON objects into their files, and now they'll properly be parsed
as they would have been on the command line.