### PR TITLE
Disable yargs behavior to optimistically parse number-seeming arguments

### DIFF
--- a/packages/api-cli/src/api.ts
+++ b/packages/api-cli/src/api.ts
@@ -136,6 +136,9 @@ const {
     }
   })
   .strict()
+  .parserConfiguration({
+    'parse-numbers': false
+  })
   .argv;
 
 let params: string[];


### PR DESCRIPTION
By default, yargs automatically converts anything that looks like a
number into one while parsing, instead of returning a list of strings.
This not only breaks the magic file middleware, but also produces
unexpected and wrong results when attempting to parse binary blobs,
which are hexadecimal strings prefixed by `0x`.

We don't want this behavior; yargs should just leave the arguments
as strings and let us parse them. This PR adds a configuration
option which disables numeric autoparsing.

---

Before:

```
root@aa304a2389eb:/# polkadot-js-api --ws ws://172.28.1.1:9944 --sudo --seed "//Alice" tx.registrar.registerPara 100 '{"scheduling":"Always"}' 0x123 0x321
param: tx.registrar.registerPara
  startsWith: [Function: startsWith]
param: 100
  startsWith: undefined
param: {"scheduling":"Always"}
  startsWith: [Function: startsWith]
param: 291
  startsWith: undefined
param: 801
  startsWith: undefined
```

After:

```
root@aa304a2389eb:/# polkadot-js-api --ws ws://172.28.1.1:9944 --sudo --seed "//Alice" tx.registrar.registerPara 100 '{"scheduling":"Always"}' 0x123 0x321
param: tx.registrar.registerPara
  startsWith: [Function: startsWith]
param: 100
  startsWith: [Function: startsWith]
param: {"scheduling":"Always"}
  startsWith: [Function: startsWith]
param: 0x123
  startsWith: [Function: startsWith]
param: 0x321
  startsWith: [Function: startsWith]
```