### PR TITLE
hash long payload before display.

### DIFF
--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -18,7 +18,7 @@ export default class RawSigner implements Signer {
     return new Promise((resolve): void => {
       const hashed = (data.length > (256 + 1) * 2)
         ? blake2AsHex(data);
-        : hashed = data;
+        : data;
 
 
       rl.question(`Payload: ${hashed}\nSignature> `, (signature) => {

--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -17,7 +17,7 @@ export default class RawSigner implements Signer {
 
     return new Promise((resolve): void => {
       const hashed = (data.length > (256 + 1) * 2)
-        ? blake2AsHex(data);
+        ? blake2AsHex(data)
         : data;
 
 

--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -23,7 +23,6 @@ export default class RawSigner implements Signer {
       } else {
         hashed = data;
       }
-			
       rl.question(`Payload: ${hashed}\nSignature> `, (signature) => {
         resolve({ id: 1, signature });
         rl.close();

--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -17,12 +17,12 @@ export default class RawSigner implements Signer {
 
     return new Promise((resolve): void => {
       let hashed;
-      
+
       if (data.length > (256 + 1) * 2) {
         hashed = blake2AsHex(data);
       } else {
         hashed = data;
-      };
+      }
 			
       rl.question(`Payload: ${hashed}\nSignature> `, (signature) => {
         resolve({ id: 1, signature });

--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -23,6 +23,7 @@ export default class RawSigner implements Signer {
       } else {
         hashed = data;
       }
+
       rl.question(`Payload: ${hashed}\nSignature> `, (signature) => {
         resolve({ id: 1, signature });
         rl.close();

--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -20,7 +20,6 @@ export default class RawSigner implements Signer {
         ? blake2AsHex(data)
         : data;
 
-
       rl.question(`Payload: ${hashed}\nSignature> `, (signature) => {
         resolve({ id: 1, signature });
         rl.close();

--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -16,12 +16,14 @@ export default class RawSigner implements Signer {
     });
 
     return new Promise((resolve): void => {
-      var hashed;
-			if ((256 + 1) * 2 < data.length) {
-				hashed = blake2AsHex(data);
-			} else {
-				hashed = data;
-			};
+      let hashed;
+      
+      if (data.length > (256 + 1) * 2) {
+        hashed = blake2AsHex(data);
+      } else {
+        hashed = data;
+      };
+			
       rl.question(`Payload: ${hashed}\nSignature> `, (signature) => {
         resolve({ id: 1, signature });
         rl.close();

--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -16,13 +16,10 @@ export default class RawSigner implements Signer {
     });
 
     return new Promise((resolve): void => {
-      let hashed;
+      const hashed = (data.length > (256 + 1) * 2)
+        ? blake2AsHex(data);
+        : hashed = data;
 
-      if (data.length > (256 + 1) * 2) {
-        hashed = blake2AsHex(data);
-      } else {
-        hashed = data;
-      }
 
       rl.question(`Payload: ${hashed}\nSignature> `, (signature) => {
         resolve({ id: 1, signature });

--- a/packages/signer-cli/src/RawSigner.ts
+++ b/packages/signer-cli/src/RawSigner.ts
@@ -4,6 +4,7 @@
 
 import { Signer, SignerResult } from '@polkadot/api/types';
 import { SignerPayloadRaw } from '@polkadot/types/types';
+import { blake2AsHex } from '@polkadot/util-crypto';
 
 import * as readline from 'readline';
 
@@ -15,7 +16,13 @@ export default class RawSigner implements Signer {
     });
 
     return new Promise((resolve): void => {
-      rl.question(`Payload: ${data}\nSignature> `, (signature) => {
+      var hashed;
+			if ((256 + 1) * 2 < data.length) {
+				hashed = blake2AsHex(data);
+			} else {
+				hashed = data;
+			};
+      rl.question(`Payload: ${hashed}\nSignature> `, (signature) => {
         resolve({ id: 1, signature });
         rl.close();
       });


### PR DESCRIPTION
This is a small change I did to be able to sign some tx with subkey, this may not be done at the right place, but probably better than the 'bad signature' error.
Reading the code I think this shall also be needed to use with the sign command from this library.