### PR TITLE
Read metadata and runtimeVersion from disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "packages/*"
   ],
   "resolutions": {
-    "@polkadot/api": "^4.7.1",
-    "@polkadot/api-derive": "^4.7.1",
+    "@polkadot/api": "^4.7.2",
+    "@polkadot/api-derive": "^4.7.2",
     "@polkadot/keyring": "^6.3.1",
-    "@polkadot/types": "^4.7.1",
+    "@polkadot/types": "^4.7.2",
     "@polkadot/util": "^6.3.1",
     "@polkadot/util-crypto": "^6.3.1",
     "typescript": "^4.2.4"

--- a/packages/metadata-cmp/README.md
+++ b/packages/metadata-cmp/README.md
@@ -1,3 +1,14 @@
 # @polkadot/metadata-cmp
 
-A utility to compare metadata from 2 sources
+A utility to compare metadata from 2 sources.
+
+NOTE: You must use a WebSocket endpoint.
+
+## Usage
+
+```
+export NODE_A=ws://localhost:9943
+export NODE_B=ws://localhost:9944
+
+yarn run:metadata $NODE_A $NODE_B
+```

--- a/packages/metadata-cmp/src/compare.ts
+++ b/packages/metadata-cmp/src/compare.ts
@@ -6,9 +6,11 @@ import type { RuntimeVersion } from '@polkadot/types/interfaces';
 import yargs from 'yargs';
 
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { expandMetadata, Metadata } from '@polkadot/metadata';
+import { expandMetadata } from '@polkadot/metadata';
 import { assert, stringCamelCase } from '@polkadot/util';
 import { readFile } from 'fs/promises';
+import { TypeRegistry } from '@polkadot/types';
+import { Metadata } from '@polkadot/metadata';
 
 const [src1, src2] = yargs.demandCommand(2).argv._ as [string, string];
 
@@ -66,10 +68,13 @@ type JsonInputFile = {
 }
 
 async function getMetadataFromDisk (filename: string): Promise<[Metadata, RuntimeVersion]> {
-  console.log("getting data from disk");
   const buffer = (await readFile(filename)).toString();
   const json = JSON.parse(buffer) as unknown as JsonInputFile;
-  const { metadata, runtimeVersion } = json;
+  const { metadata: m, runtimeVersion: r } = json;
+  const registry = new TypeRegistry();
+  const metadata = new Metadata(registry, m.toHex());
+  let runtimeVersion = registry.createType('RuntimeVersion', r);
+
   return [metadata as Metadata, runtimeVersion as RuntimeVersion];
 }
 


### PR DESCRIPTION
On top of using WebSockets to fetch metdata and runtimeversion, this PR adds the option to fetch those data directly from disk.