### PR TITLE
add more spec diffing to the metadata comparison

### DIFF
--- a/packages/metadata-cmp/src/compare.ts
+++ b/packages/metadata-cmp/src/compare.ts
@@ -97,7 +97,10 @@ async function main (): Promise<number> {
   const lvl5 = lvl1 + 4 * lvlInc;
   const chunkSize = 5;
 
-  log(lvl1, 'Spec', 'version:', createCompare(verA.specVersion.toNumber(), verB.specVersion.toNumber()));
+  log(lvl1, 'Spec', 'name:', createCompare(verA.specName.toString(), verB.specName.toString()));
+  log(lvl1, '', 'spec_version:', createCompare(verA.specVersion.toNumber(), verB.specVersion.toNumber()));
+  log(lvl1, '', 'transaction_version:',
+    createCompare(verA.transactionVersion.toNumber(), verB.transactionVersion.toNumber()));
   log(lvl1, 'Metadata', 'version:', createCompare(metaA.version, metaB.version));
 
   const mA = a.pallets.map(({ name }) => name.toString());


### PR DESCRIPTION
Adds more diffing for the RuntimeVersion to the metadata comparison tool.

We might want to consider diffing 
```ts
export interface RuntimeVersion extends Struct {
    readonly specName: Text;
    readonly implName: Text;
    readonly authoringVersion: u32;
    readonly specVersion: u32;
    readonly implVersion: u32;
    readonly apis: Vec<RuntimeVersionApi>;
    readonly transactionVersion: u32;
}
```
more completely