### PR TITLE
Adjust error messages for not-exposed pallets and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Adjust error messages for not-exposed pallets and methods
+
+
 ## 0.48.13 Jan 23, 2022
 
 Changes:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Jaco Greeff <jacogr@gmail.com>",
   "bugs": "https://github.com/polkadot-js/tools/issues",
   "homepage": "https://github.com/polkadot-js/tools#readme",
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "packageManager": "yarn@3.0.1",
   "private": true,
   "repository": {
@@ -32,7 +32,7 @@
     "@babel/core": "^7.16.12",
     "@babel/register": "^7.16.9",
     "@babel/runtime": "^7.16.7",
-    "@polkadot/dev": "^0.65.43",
+    "@polkadot/dev": "^0.65.44",
     "@types/node": "^17.0.10",
     "@types/yargs": "^17.0.8"
   },

--- a/packages/api-cli/src/api.ts
+++ b/packages/api-cli/src/api.ts
@@ -163,6 +163,8 @@ Example: --seed "//Alice" tx.balances.transfer F7Gh 10000`
 const { _: [endpoint, ...paramsInline], assetId, info, noWait, params: paramsFile, seed, sign, sub, sudo, sudoUncheckedWeight, tip, ws } = argv;
 const params = parseParams(paramsInline, paramsFile);
 
+const ALLOWED = ['consts', 'derive', 'query', 'rpc', 'tx'];
+
 function readFile <T> (src: string): T {
   if (!src) {
     return {} as T;
@@ -184,9 +186,9 @@ async function getCallInfo (): Promise<CallInfo> {
   const apiExt = (api as unknown) as ApiExt;
   const [type, section, method] = endpoint.split('.') as [keyof ApiExt, string, string];
 
-  assert(['consts', 'derive', 'query', 'rpc', 'tx'].includes(type), `Expected one of consts, derive, query, rpc, tx, found ${type}`);
-  assert(apiExt[type][section], `Cannot find ${type}.${section}`);
-  assert(apiExt[type][section][method], `Cannot find ${type}.${section}.${method}`);
+  assert(ALLOWED.includes(type), `Expected one of ${ALLOWED.join(', ')}, found ${type}`);
+  assert(apiExt[type][section], `Cannot find ${type}.${section}, your chain does not have the ${section} pallet exposed in the runtime`);
+  assert(apiExt[type][section][method], `Cannot find ${type}.${section}.${method}, your chain doesn't have the ${method} exposed in the ${section} pallet`);
 
   const fn = apiExt[type][section][method];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,9 +1959,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/dev@npm:^0.65.43":
-  version: 0.65.43
-  resolution: "@polkadot/dev@npm:0.65.43"
+"@polkadot/dev@npm:^0.65.44":
+  version: 0.65.44
+  resolution: "@polkadot/dev@npm:0.65.44"
   dependencies:
     "@babel/cli": ^7.16.8
     "@babel/core": ^7.16.12
@@ -2047,7 +2047,7 @@ __metadata:
     polkadot-exec-rollup: scripts/polkadot-exec-rollup.mjs
     polkadot-exec-tsc: scripts/polkadot-exec-tsc.mjs
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.mjs
-  checksum: cebdfe1fa6325a7b29599478eb3ee5350f96f1d51a781dcd5625310008ae9a884927a4b43d57c9319a1446f9e9f5db293ce74ace798cdee34e40d04277e759f2
+  checksum: 8453e5b1a176035484df1334ae3c54cb1d0d87948349e6deed3b57649fff6b4ee2a8c6c8231f1de028eee3762166d006b9babc7c82fd31d573c6ab3136655b35
   languageName: node
   linkType: hard
 
@@ -9349,7 +9349,7 @@ resolve@^2.0.0-next.3:
     "@babel/core": ^7.16.12
     "@babel/register": ^7.16.9
     "@babel/runtime": ^7.16.7
-    "@polkadot/dev": ^0.65.43
+    "@polkadot/dev": ^0.65.44
     "@types/node": ^17.0.10
     "@types/yargs": ^17.0.8
   languageName: unknown


### PR DESCRIPTION
Makes it clearer as to "why" this happens, e.g. https://github.com/polkadot-js/tools/issues/329#issue-1111114639

Basically it now explicitly indicates that the runtime does not expose the pallet (or method on the pallet)