### PR TITLE
Support ecdsa signatures in signer CLI

### DIFF
--- a/packages/signer-cli/src/cmdSign.ts
+++ b/packages/signer-cli/src/cmdSign.ts
@@ -9,7 +9,7 @@ import { Keyring } from '@polkadot/keyring';
 import { assert, hexToU8a, isHex, u8aToHex } from '@polkadot/util';
 import { cryptoWaitReady, keyExtractSuri, mnemonicValidate } from '@polkadot/util-crypto';
 
-type Curves = 'ed25519' | 'sr25519';
+type Curves = 'ed25519' | 'sr25519' | 'ecdsa';
 
 const SEED_LENGTHS = [12, 15, 18, 21, 24];
 

--- a/packages/signer-cli/src/signer.ts
+++ b/packages/signer-cli/src/signer.ts
@@ -56,7 +56,7 @@ const { _: [command, ...paramsInline], account, blocks, minutes, nonce, params: 
       type: 'string'
     },
     type: {
-      choices: ['ed25519', 'sr25519'],
+      choices: ['ed25519', 'sr25519', 'ecdsa'],
       default: 'sr25519',
       description: 'The account crypto signature to use (sign only)',
       type: 'string'


### PR DESCRIPTION
This PR adds `ecdsa` as an allowed curve for the `signer` command. Since there's already support in `@polkadot/keyring` this only requires updating the allowed CLI arguments.