### PR TITLE
Support ecdsa signatures in api CLI

### DIFF
--- a/packages/api-cli/src/api.ts
+++ b/packages/api-cli/src/api.ts
@@ -84,7 +84,7 @@ interface Params {
   tip: number;
 }
 
-const CRYPTO = ['ed25519', 'sr25519', 'ethereum'];
+const CRYPTO = ['ed25519', 'sr25519', 'ethereum', 'ecdsa'];
 
 // retrieve and parse arguments - we do this globally, since this is a single command
 const argv = yargs


### PR DESCRIPTION
Basically the same as #344, but for the `api` tool