### PR TITLE
Align tsconfig to allow moduleResolution: nodenext

### DIFF
--- a/packages/api-cli/package.json
+++ b/packages/api-cli/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/polkadot-js/tools.git"
   },
   "sideEffects": false,
+  "type": "module",
   "version": "0.53.3-1-x",
   "main": "index.js",
   "bin": {

--- a/packages/api-cli/src/cli.ts
+++ b/packages/api-cli/src/cli.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 @polkadot/api-cli authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ArgV } from './types';
+import type { ArgV } from './types.js';
 
 import fs from 'node:fs';
 

--- a/packages/json-serve/package.json
+++ b/packages/json-serve/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/polkadot-js/tools.git"
   },
   "sideEffects": false,
+  "type": "module",
   "version": "0.53.3-1-x",
   "main": "index.js",
   "bin": {

--- a/packages/metadata-cmp/package.json
+++ b/packages/metadata-cmp/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/polkadot-js/tools.git"
   },
   "sideEffects": false,
+  "type": "module",
   "version": "0.53.3-1-x",
   "main": "index.js",
   "bin": {

--- a/packages/monitor-rpc/package.json
+++ b/packages/monitor-rpc/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/polkadot-js/tools.git"
   },
   "sideEffects": false,
+  "type": "module",
   "version": "0.53.3-1-x",
   "main": "index.js",
   "bin": {

--- a/packages/signer-cli/package.json
+++ b/packages/signer-cli/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/polkadot-js/tools.git"
   },
   "sideEffects": false,
+  "type": "module",
   "version": "0.53.3-1-x",
   "main": "index.js",
   "bin": {

--- a/packages/vanitygen/package.json
+++ b/packages/vanitygen/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/polkadot-js/tools.git"
   },
   "sideEffects": false,
+  "type": "module",
   "version": "0.53.3-1-x",
   "main": "index.js",
   "bin": {

--- a/packages/vanitygen/src/calculate.ts
+++ b/packages/vanitygen/src/calculate.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/vanitygen authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { GeneratorCalculation, GeneratorOptions } from './types';
+import type { GeneratorCalculation, GeneratorOptions } from './types.js';
 
 const MAX_OFFSET = 5;
 

--- a/packages/vanitygen/src/generate.ts
+++ b/packages/vanitygen/src/generate.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/vanitygen authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { GeneratorMatch, GeneratorOptions } from './types';
+import type { GeneratorMatch, GeneratorOptions } from './types.js';
 
 import { ed25519PairFromSeed, encodeAddress, mnemonicGenerate, mnemonicToMiniSecret, randomAsU8a, sr25519PairFromSeed } from '@polkadot/util-crypto';
 

--- a/packages/vanitygen/src/generator.ts
+++ b/packages/vanitygen/src/generator.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/vanitygen authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { GeneratorMatches, GeneratorOptions, GeneratorResult } from './types';
+import type { GeneratorMatches, GeneratorOptions, GeneratorResult } from './types.js';
 
 import generate from './generate.js';
 

--- a/packages/vanitygen/src/runcli.ts
+++ b/packages/vanitygen/src/runcli.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { KeypairType } from '@polkadot/util-crypto/types';
-import type { GeneratorOptions } from './types';
+import type { GeneratorOptions } from './types.js';
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,19 +2,19 @@
   "extends": "@polkadot/dev/config/tsconfig.json",
 	"compilerOptions": {
 		"composite": true,
+    "moduleResolution": "nodenext",
 		"paths": {
-      "@polkadot/api-cli": ["api-cli/src"],
-      "@polkadot/api-cli/*": ["api-cli/src/*"],
-      "@polkadot/json-serve": ["json-serve/src"],
-      "@polkadot/json-serve/*": ["json-serve/src/*"],
-      "@polkadot/metadata-cmp": ["metadata-cmp/src"],
-      "@polkadot/metadata-cmp/*": ["metadata-cmp/src/*"],
-      "@polkadot/monitor-rpc": ["monitor-rpc/src"],
-      "@polkadot/monitor-rpc/*": ["monitor-rpc/src/*"],
-      "@polkadot/signer-cli": ["signer-cli/src"],
-      "@polkadot/signer-cli/*": ["signer-cli/src/*"]
+      "@polkadot/api-cli": ["api-cli/src/index.ts"],
+      "@polkadot/api-cli/*": ["api-cli/src/*.ts"],
+      "@polkadot/json-serve": ["json-serve/src/index.ts"],
+      "@polkadot/json-serve/*": ["json-serve/src/*.ts"],
+      "@polkadot/metadata-cmp": ["metadata-cmp/src/index.ts"],
+      "@polkadot/metadata-cmp/*": ["metadata-cmp/src/*.ts"],
+      "@polkadot/monitor-rpc": ["monitor-rpc/src/index.ts"],
+      "@polkadot/monitor-rpc/*": ["monitor-rpc/src/*.ts"],
+      "@polkadot/signer-cli": ["signer-cli/src/index.ts"],
+      "@polkadot/signer-cli/*": ["signer-cli/src/*.ts"]
     },
-    "skipLibCheck": true,
-    "target": "es2020"
+    "skipLibCheck": true
 	}
  }


### PR DESCRIPTION
Follow-up for https://github.com/polkadot-js/api/issues/5524 (when we finally enable `"moduleResolution": "nodenext"` in `@polkadot/dev`)