### PR TITLE
Use Node LTS on docker (& swap base to latest)

### DIFF
--- a/docker/Dockerfile.tmpl
+++ b/docker/Dockerfile.tmpl
@@ -6,12 +6,12 @@
 # from npm to do the the actual versioned build
 
 # base image
-FROM ubuntu:18.04
+FROM ubuntu:22.10
 
 # Run package updates
 RUN apt-get update && \
   apt-get install -y curl gcc g++ gnupg make python git
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
 RUN apt-get install -y nodejs
 
 # env variable works around gyp install (secp256k1) with root permissions


### PR DESCRIPTION
Closes https://github.com/polkadot-js/tools/issues/461

For Node.js this is great since it will always pull the latest LTS (which is intended). The previously-used Node 14.x is actually EOL by April 2023. 

For Ubuntu there is no lts concept, so just bump that to latest, non-dev. 

