### PR TITLE
Push the version tag to Docker

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -43,6 +43,7 @@ function publish () {
 
   echo "*** Publishing $NAME"
   docker push $REPO/$NAME
+  docker push $REPO/$NAME:$VERSION
 
   exit 0
 }


### PR DESCRIPTION
Turns out the default is to push only one tag at a time. I'm rusty on my docker apparently.

This will push the second tag.

An alternative is to use `--all-tags`, but that doesn't feel safe to me.

Follow up to: https://github.com/polkadot-js/tools/pull/459