### PR TITLE
metadata-cmp: Properly handle pallets with no extrinsics

### DIFF
--- a/packages/metadata-cmp/src/runcli.ts
+++ b/packages/metadata-cmp/src/runcli.ts
@@ -136,7 +136,7 @@ async function main (): Promise<number> {
       const count = createCompare(eA.length, eB.length);
       const storage = createCompare(sA.length, sB.length);
       const post = `calls: ${count}, storage: ${storage}`;
-      const index = createCompare(decA.tx[n][eA[0]]?.callIndex[0], decB.tx[n][eB[0]]?.callIndex[0]);
+      const index = createCompare(decA.tx[n]?.[eA[0]]?.callIndex[0], decB.tx[n]?.[eB[0]]?.callIndex[0]);
 
       log(lvl2, m, 'idx:', index, post);
 


### PR DESCRIPTION
We use the `polkadot-js-metadata-cmp` tool in our CI and it works wonderfully, but we recently started getting type errors with the traceback:

```
TypeError: Cannot read properties of undefined (reading 'undefined')
    at <snip>/@polkadot/metadata-cmp/lib/node_modules/@polkadot/metadata-cmp/runcli.js:97:47
    at Array.forEach (<anonymous>)
    at main (<snip>/@polkadot/metadata-cmp/lib/node_modules/@polkadot/metadata-cmp/runcli.js:82:10)
```

It turns out this was because we removed all of the extrinsics from a pallet. This PR fixes the error by just optionally chaining after we look up the list of extrinsics for a given pallet.