### PR TITLE
Added nonce argument to polkadot-js-api

### DIFF
--- a/packages/api-cli/src/runcli.ts
+++ b/packages/api-cli/src/runcli.ts
@@ -263,7 +263,7 @@ async function makeTx ({ api, fn, log }: CallInfo): Promise<(() => void) | Hash>
     signable = fn(...params);
   }
 
-  return signable.signAndSend(signer, { assetId, tip, nonce }, (result: SubmittableResult): void => {
+  return signable.signAndSend(signer, { assetId, nonce, tip }, (result: SubmittableResult): void => {
     log(result);
 
     if (noWait || result.isInBlock || result.isFinalized) {

--- a/packages/api-cli/src/runcli.ts
+++ b/packages/api-cli/src/runcli.ts
@@ -68,6 +68,7 @@ interface Params {
   _: string[];
   info: boolean;
   noWait: boolean;
+  nonce: number;
   params: string;
   rpc: string;
   seed: string;
@@ -92,7 +93,8 @@ const argv = yargs(hideBin(process.argv))
   .command('$0', `Usage: [options] <endpoint> <...params>
 Example: query.system.account 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKv3gB
 Example: query.substrate.code --info
-Example: --seed "//Alice" tx.balances.transfer F7Gh 10000`
+Example: --seed "//Alice" tx.balances.transfer F7Gh 10000
+Example: --seed "//Alice" --noWait --nonce -1 tx.balances.transfer F7Gh 10000`
   )
   .middleware(hexMiddleware)
   .middleware(jsonMiddleware)
@@ -109,6 +111,10 @@ Example: --seed "//Alice" tx.balances.transfer F7Gh 10000`
     noWait: {
       description: 'After sending a tx return immediately and don\'t wait until it is included in a block',
       type: 'boolean'
+    },
+    nonce: {
+      description: 'An account nonce to be used when signing tx. -1 means to read it from node (including tx pool)',
+      type: 'number'
     },
     params: {
       description: 'Location of file containing space-separated transaction parameters (optional)',
@@ -157,7 +163,7 @@ Example: --seed "//Alice" tx.balances.transfer F7Gh 10000`
   })
   .argv as Params;
 
-const { _: [endpoint, ...paramsInline], assetId, info, noWait, params: paramsFile, seed, sign, sub, sudo, sudoUncheckedWeight, tip, ws } = argv;
+const { _: [endpoint, ...paramsInline], assetId, info, noWait, nonce, params: paramsFile, seed, sign, sub, sudo, sudoUncheckedWeight, tip, ws } = argv;
 const params = parseParams(paramsInline, paramsFile);
 
 const ALLOWED = ['consts', 'derive', 'query', 'rpc', 'tx'];
@@ -257,7 +263,7 @@ async function makeTx ({ api, fn, log }: CallInfo): Promise<(() => void) | Hash>
     signable = fn(...params);
   }
 
-  return signable.signAndSend(signer, { assetId, tip }, (result: SubmittableResult): void => {
+  return signable.signAndSend(signer, { assetId, tip, nonce }, (result: SubmittableResult): void => {
     log(result);
 
     if (noWait || result.isInBlock || result.isFinalized) {


### PR DESCRIPTION
The logic which determines nonce that is used when signing transaction [is here](https://github.com/polkadot-js/api/blob/fca68ae286bed7098ca5c7d234fadebb626e263e/packages/api-derive/src/tx/signingInfo.ts#L70-L75):
```js
      isUndefined(nonce)
        ? latestNonce(api, address)
        : nonce === -1
          ? nextNonce(api, address)
          : of(api.registry.createType('Index', nonce)),
```

So it is:
1) if `nonce` is specified by the caller AND it is not `-1`, then it is used
2) if `nonce` is specified by the caller AND it is `-1`, then it is read from the node using `api.rpc.system.accountNextIndex(_)`, which returns next nonce, taking into account all extrinsics from the pool
3) if `nonce` is not specified by the caller, then it is read from the node using `api.derive.balances.account(_).accountNonce`, which returns next nonce, **NOT** taking into account all extrinsics from the pool

The `polkadot-js-api` cli package doesn't pass the `nonce`, hence it always uses the 3rd option, which effectively limits number of transactions to one per block (because all following submissions will fail because the same nonce is used). We are using this package (thank you @jacogr ) in bridges tests and we want to submit more than 1 tx per block, hence this PR