### PR TITLE
[api-cli] Avoid infinite wait on failed txs

### DIFF
--- a/packages/api-cli/src/runcli.ts
+++ b/packages/api-cli/src/runcli.ts
@@ -269,6 +269,10 @@ async function makeTx ({ api, fn, log }: CallInfo): Promise<(() => void) | Hash>
     if (noWait || result.isInBlock || result.isFinalized) {
       process.exit(0);
     }
+
+    if (result.isError) {
+      process.exit(1);
+    }
   });
 }
 


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-sdk/issues/3176

We use `polkadot-js-api` as part of the bridge integration tests. Lately, since async backing was enabled for test system parachains we are seeing an increasing number of invalid txs in our tests because of https://github.com/paritytech/polkadot-sdk/issues/3204

As a workaround I plan to just disregard these error statuses, but we also need `polkadot-js-api` to gracefully close in this case.