### PR TITLE
Set metadata cli to use v15, and add --legacy flag

### DIFF
--- a/packages/metadata-cmp/README.md
+++ b/packages/metadata-cmp/README.md
@@ -1,3 +1,15 @@
 # @polkadot/metadata-cmp
 
 A utility to compare metadata from 2 sources
+
+## Usage
+
+Commands are of the form,
+
+```
+yarn run:metadata <ws1> <ws2> [options]
+```
+
+Where `ws1` is the first websocket, and `ws2` is the second websocket. The `options` are as follows:
+
+`--legacy`: Use of the legacy rpc method `api.rpc.state.getMetadata` for retrieving metadata. When this is false or empty the default `api.call.metadata.metadataAtVersion` will be used.

--- a/packages/metadata-cmp/package.json
+++ b/packages/metadata-cmp/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@polkadot/api": "^15.4.1",
+    "@polkadot/api-augment": "^15.4.1",
     "@polkadot/keyring": "^13.3.1",
     "@polkadot/types": "^15.4.1",
     "@polkadot/util": "^13.3.1",

--- a/packages/metadata-cmp/src/runcli.ts
+++ b/packages/metadata-cmp/src/runcli.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2025 @polkadot/metadata-cmp authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Metadata } from '@polkadot/types';
 import type { RuntimeVersion, StorageEntryMetadataLatest } from '@polkadot/types/interfaces';
 import type { Registry } from '@polkadot/types/types';
 
@@ -9,16 +8,26 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { expandMetadata } from '@polkadot/types';
+import { expandMetadata, Metadata } from '@polkadot/types';
 import { getSiName } from '@polkadot/types/metadata/util';
 import { unwrapStorageType } from '@polkadot/types/util';
 import { assert, stringCamelCase } from '@polkadot/util';
 
 interface ArgV {
-  _: [string, string]
+  _: [string, string];
+  legacy: boolean;
 }
 
-const [ws1, ws2] = (yargs(hideBin(process.argv)).demandCommand(2).argv as unknown as ArgV)._;
+const argv = (yargs(hideBin(process.argv)).demandCommand(2).options({
+  legacy: {
+    default: false,
+    description: 'Using rpc.state.getMetadata to retrieve metadata. The highest supported metadata version will be 14.',
+    type: 'boolean'
+  }
+}).argv as unknown as ArgV);
+
+const [ws1, ws2] = argv._;
+const legacy = argv.legacy;
 
 // configure padding
 const lvlInc = 14;
@@ -76,7 +85,7 @@ function expandMapKey ({ lookup }: Registry, { type }: StorageEntryMetadataLates
   ];
 }
 
-async function getMetadata (url: string): Promise<[Registry, Metadata, RuntimeVersion]> {
+async function getMetadataLegacy (url: string, useLegacyRpc: boolean): Promise<[Registry, Metadata, RuntimeVersion]> {
   assert(url.startsWith('ws://') || url.startsWith('wss://'), `Invalid WebSocket endpoint ${url}, expected ws:// or wss://`);
 
   const provider = new WsProvider(url);
@@ -84,16 +93,29 @@ async function getMetadata (url: string): Promise<[Registry, Metadata, RuntimeVe
 
   provider.on('error', () => process.exit());
 
-  return Promise.all([
-    Promise.resolve(api.registry),
-    api.rpc.state.getMetadata(),
-    api.rpc.state.getRuntimeVersion()
-  ]);
+  if (useLegacyRpc) {
+    return Promise.all([
+      Promise.resolve(api.registry),
+      api.rpc.state.getMetadata(),
+      api.rpc.state.getRuntimeVersion()
+    ]);
+  } else {
+    const versions = await api.call.metadata.metadataVersions();
+    // The versions should be sorted from least to greatest.
+    const version = versions[versions.length - 1];
+    const meta = await api.call.metadata.metadataAtVersion(version);
+
+    return Promise.all([
+      Promise.resolve(api.registry),
+      Promise.resolve(new Metadata(api.registry, meta.unwrap())),
+      api.rpc.state.getRuntimeVersion()
+    ]);
+  }
 }
 
 // our main entry point - from here we call out
 async function main (): Promise<number> {
-  const [[regA, metaA, verA], [regB, metaB, verB]] = await Promise.all([getMetadata(ws1), getMetadata(ws2)]);
+  const [[regA, metaA, verA], [regB, metaB, verB]] = await Promise.all([getMetadataLegacy(ws1, legacy), getMetadataLegacy(ws2, legacy)]);
   const a = metaA.asLatest;
   const b = metaB.asLatest;
 

--- a/packages/metadata-cmp/src/runcli.ts
+++ b/packages/metadata-cmp/src/runcli.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2025 @polkadot/metadata-cmp authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import '@polkadot/api-augment';
+
 import type { RuntimeVersion, StorageEntryMetadataLatest } from '@polkadot/types/interfaces';
 import type { Registry } from '@polkadot/types/types';
 
@@ -91,6 +93,8 @@ async function getMetadataLegacy (url: string, useLegacyRpc: boolean): Promise<[
   const provider = new WsProvider(url);
   const api = await ApiPromise.create({ provider });
 
+  await api.isReady;
+
   provider.on('error', () => process.exit());
 
   if (useLegacyRpc) {
@@ -102,7 +106,7 @@ async function getMetadataLegacy (url: string, useLegacyRpc: boolean): Promise<[
   } else {
     const versions = await api.call.metadata.metadataVersions();
     // The versions should be sorted from least to greatest.
-    const version = versions[versions.length - 1];
+    const version = versions.toArray()[versions.length - 1];
     const meta = await api.call.metadata.metadataAtVersion(version);
 
     return Promise.all([

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,6 +674,7 @@ __metadata:
   resolution: "@polkadot/metadata-cmp@workspace:packages/metadata-cmp"
   dependencies:
     "@polkadot/api": "npm:^15.4.1"
+    "@polkadot/api-augment": "npm:^15.4.1"
     "@polkadot/keyring": "npm:^13.3.1"
     "@polkadot/types": "npm:^15.4.1"
     "@polkadot/util": "npm:^13.3.1"


### PR DESCRIPTION
Breaking change:

the `metadata-cmp` CLI no longer will use `api.rpc.state.getMetadata` to retrieve metadata. It will always default to using the appropriate runtime calls for the latest version. If one would like to revert to using the legacy rpc call they can use the `--legacy` flag.