### PR TITLE
Submitting hex encoded extrinsic with api-cli

### DIFF
--- a/packages/api-cli/README.md
+++ b/packages/api-cli/README.md
@@ -55,6 +55,17 @@ yarn run:api --sudo --seed "//Alice" tx.system.setCode @test.wasm
 
 In all cases when sudoing, the seed provided should be that of the superuser. For most development nets, that is `"//Alice"`.
 
+### Encoded Call
+
+Transactions can now be submitted using an encoded hex call. This is useful for complex extrinsics that are difficult to craft manually via the CLI. Instead, build the transaction using the [Polkadot-JS Apps UI](https://polkadot.js.org/apps/#/extrinsics), copy the encoded call, and execute it via CLI.
+
+```
+yarn run:api --encodedCall <encoded_call> --seed "<seed>" --ws <ws_endpoint>
+```
+
+```
+yarn run:api --encodedCall 0x050300fe580ec5fe0e9569d645375acecf5aa19bc0b3188ddd2e2ffc68f6548590d61e0700e8764817 --seed "//Alice" --ws wss://paseo-rpc.dwellir.com
+```
 
 ## Global Installation
 

--- a/packages/api-cli/src/runcli.ts
+++ b/packages/api-cli/src/runcli.ts
@@ -174,6 +174,14 @@ const params = parseParams(paramsInline, paramsFile);
 
 const ALLOWED = ['consts', 'derive', 'query', 'rpc', 'tx'];
 
+async function initApi (): Promise<ApiPromise> {
+  const rpc = readFile<ApiOptions['rpc']>(argv.rpc);
+  const types = readFile<ApiOptions['types']>(argv.types);
+  const provider = new WsProvider(ws);
+
+  return await ApiPromise.create({ provider, rpc, types });
+}
+
 function readFile <T> (src: string): NonNullable<T> {
   if (!src) {
     return {} as NonNullable<T>;
@@ -188,10 +196,7 @@ function readFile <T> (src: string): NonNullable<T> {
 async function getCallInfo (): Promise<CallInfo> {
   assert(endpoint && endpoint.includes('.'), 'You need to specify the command to execute, e.g. query.system.account');
 
-  const rpc = readFile<ApiOptions['rpc']>(argv.rpc);
-  const types = readFile<ApiOptions['types']>(argv.types);
-  const provider = new WsProvider(ws);
-  const api = await ApiPromise.create({ provider, rpc, types });
+  const api = await initApi();
   const apiExt = (api as unknown) as ApiExt;
   const [type, section, method] = endpoint.split('.') as [keyof ApiExt, string, string];
 
@@ -304,10 +309,7 @@ async function makeCall ({ fn, log, method, type }: CallInfo): Promise<void> {
 }
 
 async function submitEncodedCall () {
-  const rpc = readFile<ApiOptions['rpc']>(argv.rpc);
-  const types = readFile<ApiOptions['types']>(argv.types);
-  const provider = new WsProvider(ws);
-  const api = await ApiPromise.create({ provider, rpc, types });
+  const api = await initApi();
   const call = api.createType('Call', argv.encodedCall);
   const { method, section } = api.registry.findMetaCall(call.callIndex);
 


### PR DESCRIPTION
## 📝 Description

This PR introduces support for passing hex-encoded extrinsic calls directly to the `api-cli` tools.

Previously, crafting complex transactions through the CLI was cumbersome and error-prone, especially for calls involving nested or opaque parameters. In some cases, certain transactions could not be constructed at all via the CLI.

In [Polkadot-JS UI](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.ibp.network%2Fpolkadot#/extrinsics/decode/0x00001074657374), users can generate a hex-encoded representation of an extrinsic. This update allows CLI users to input such hex strings directly, significantly simplifying the process for submitting advanced transactions.

## Usage

```bash
yarn run:api 
  --encodedCall 0x050300fe580ec5fe0e9569d645375acecf5aa19bc0b3188ddd2e2ffc68f6548590d61e0700e8764817 
  --seed "evoke.....faint"
  --ws wss://paseo.rpc.amforc.com
```

https://paseo.subscan.io/extrinsic/6685540-2