### PR TITLE
chore: upgrade polkadot dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "yarn run:api --help && yarn run:json --help && yarn run:metadata --help && yarn run:monitor --help && yarn run:signer --help && yarn run:vanity --help"
   },
   "devDependencies": {
-    "@polkadot/dev": "^0.83.2",
+    "@polkadot/dev": "^0.83.3",
     "@types/node": "^22.10.5",
     "@types/yargs": "^17.0.33"
   },

--- a/packages/api-cli/package.json
+++ b/packages/api-cli/package.json
@@ -21,12 +21,12 @@
     "polkadot-js-api": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.1.2",
-    "@polkadot/api-augment": "^16.1.2",
-    "@polkadot/keyring": "^13.5.1",
-    "@polkadot/types": "^16.1.2",
-    "@polkadot/util": "^13.5.1",
-    "@polkadot/util-crypto": "^13.5.1",
+    "@polkadot/api": "^16.2.2",
+    "@polkadot/api-augment": "^16.2.2",
+    "@polkadot/keyring": "^13.5.2",
+    "@polkadot/types": "^16.2.2",
+    "@polkadot/util": "^13.5.2",
+    "@polkadot/util-crypto": "^13.5.2",
     "tslib": "^2.8.1",
     "yargs": "^17.7.2"
   },

--- a/packages/json-serve/package.json
+++ b/packages/json-serve/package.json
@@ -21,11 +21,11 @@
     "polkadot-js-json-serve": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.1.2",
-    "@polkadot/api-augment": "^16.1.2",
-    "@polkadot/api-derive": "^16.1.2",
-    "@polkadot/types": "^16.1.2",
-    "@polkadot/util": "^13.5.1",
+    "@polkadot/api": "^16.2.2",
+    "@polkadot/api-augment": "^16.2.2",
+    "@polkadot/api-derive": "^16.2.2",
+    "@polkadot/types": "^16.2.2",
+    "@polkadot/util": "^13.5.2",
     "koa": "^2.14.2",
     "koa-route": "^3.2.0",
     "tslib": "^2.8.1",

--- a/packages/metadata-cmp/package.json
+++ b/packages/metadata-cmp/package.json
@@ -21,11 +21,11 @@
     "polkadot-js-metadata-cmp": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.1.2",
-    "@polkadot/api-augment": "^16.1.2",
-    "@polkadot/keyring": "^13.5.1",
-    "@polkadot/types": "^16.1.2",
-    "@polkadot/util": "^13.5.1",
+    "@polkadot/api": "^16.2.2",
+    "@polkadot/api-augment": "^16.2.2",
+    "@polkadot/keyring": "^13.5.2",
+    "@polkadot/types": "^16.2.2",
+    "@polkadot/util": "^13.5.2",
     "tslib": "^2.8.1",
     "yargs": "^17.7.2"
   },

--- a/packages/monitor-rpc/package.json
+++ b/packages/monitor-rpc/package.json
@@ -21,9 +21,9 @@
     "polkadot-js-monitor": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.1.2",
-    "@polkadot/types": "^16.1.2",
-    "@polkadot/util": "^13.5.1",
+    "@polkadot/api": "^16.2.2",
+    "@polkadot/types": "^16.2.2",
+    "@polkadot/util": "^13.5.2",
     "koa": "^2.14.2",
     "koa-route": "^3.2.0",
     "tslib": "^2.8.1",

--- a/packages/signer-cli/package.json
+++ b/packages/signer-cli/package.json
@@ -21,12 +21,12 @@
     "polkadot-js-signer": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.1.2",
+    "@polkadot/api": "^16.2.2",
     "@polkadot/api-cli": "^0.63.10-0-x",
-    "@polkadot/keyring": "^13.5.1",
-    "@polkadot/types": "^16.1.2",
-    "@polkadot/util": "^13.5.1",
-    "@polkadot/util-crypto": "^13.5.1",
+    "@polkadot/keyring": "^13.5.2",
+    "@polkadot/types": "^16.2.2",
+    "@polkadot/util": "^13.5.2",
+    "@polkadot/util-crypto": "^13.5.2",
     "tslib": "^2.8.1",
     "yargs": "^17.7.2"
   },

--- a/packages/vanitygen/package.json
+++ b/packages/vanitygen/package.json
@@ -21,8 +21,8 @@
     "polkadot-js-vanitygen": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/util": "^13.5.1",
-    "@polkadot/util-crypto": "^13.5.1",
+    "@polkadot/util": "^13.5.2",
+    "@polkadot/util-crypto": "^13.5.2",
     "tslib": "^2.8.1",
     "yargs": "^17.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,7 +447,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:16.1.2, @polkadot/api-augment@npm:^16.1.2":
+"@polkadot/api-augment@npm:16.1.2":
   version: 16.1.2
   resolution: "@polkadot/api-augment@npm:16.1.2"
   dependencies:
@@ -459,6 +459,21 @@ __metadata:
     "@polkadot/util": "npm:^13.5.1"
     tslib: "npm:^2.8.1"
   checksum: 10/94ee307d5bf9e88d2dd9ea1e50f6e8e5b34b7c14e0fad99f05609a31022589bd27a0f837dd8d10ada8c7687586cb7dda5f28f646f5a5b9f7a12a3e11d70b9a55
+  languageName: node
+  linkType: hard
+
+"@polkadot/api-augment@npm:^16.2.2":
+  version: 16.2.2
+  resolution: "@polkadot/api-augment@npm:16.2.2"
+  dependencies:
+    "@polkadot/api-base": "npm:16.2.2"
+    "@polkadot/rpc-augment": "npm:16.2.2"
+    "@polkadot/types": "npm:16.2.2"
+    "@polkadot/types-augment": "npm:16.2.2"
+    "@polkadot/types-codec": "npm:16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
+    tslib: "npm:^2.8.1"
+  checksum: 10/79db0ff652ab2f63819acec9085866a30e566f16723b3e9adb330418e3a1f0b2b5475c0adb42fc1f283d28410e6a56d642821c7b3bdd2a1ed5066f93032988bf
   languageName: node
   linkType: hard
 
@@ -475,16 +490,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/api-base@npm:16.2.2":
+  version: 16.2.2
+  resolution: "@polkadot/api-base@npm:16.2.2"
+  dependencies:
+    "@polkadot/rpc-core": "npm:16.2.2"
+    "@polkadot/types": "npm:16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
+    rxjs: "npm:^7.8.1"
+    tslib: "npm:^2.8.1"
+  checksum: 10/5dcd3735af36dc31687d6e4753b31a1ef6330cbba11df3010a09d47e7f06ae80e7a81512e2fdc2db392c93a9f42e66b116f34ae6e51eeb966a84a2bb95d2508a
+  languageName: node
+  linkType: hard
+
 "@polkadot/api-cli@npm:^0.63.10-0-x, @polkadot/api-cli@workspace:packages/api-cli":
   version: 0.0.0-use.local
   resolution: "@polkadot/api-cli@workspace:packages/api-cli"
   dependencies:
-    "@polkadot/api": "npm:^16.1.2"
-    "@polkadot/api-augment": "npm:^16.1.2"
-    "@polkadot/keyring": "npm:^13.5.1"
-    "@polkadot/types": "npm:^16.1.2"
-    "@polkadot/util": "npm:^13.5.1"
-    "@polkadot/util-crypto": "npm:^13.5.1"
+    "@polkadot/api": "npm:^16.2.2"
+    "@polkadot/api-augment": "npm:^16.2.2"
+    "@polkadot/keyring": "npm:^13.5.2"
+    "@polkadot/types": "npm:^16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
+    "@polkadot/util-crypto": "npm:^13.5.2"
     "@types/node": "npm:^22.10.5"
     "@types/yargs": "npm:^17.0.33"
     tslib: "npm:^2.8.1"
@@ -537,34 +565,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/dev-test@npm:^0.83.2":
-  version: 0.83.2
-  resolution: "@polkadot/dev-test@npm:0.83.2"
+"@polkadot/dev-test@npm:^0.83.3":
+  version: 0.83.3
+  resolution: "@polkadot/dev-test@npm:0.83.3"
   dependencies:
     jsdom: "npm:^24.0.0"
     tslib: "npm:^2.7.0"
-  checksum: 10/afe60165272a09d5c9f08e3aec0015621350dc7394ee8ff121d5803c576c7601b176b753716203abba4a81a142b529da066fe4c73f39387b018bdde69fef7a10
+  checksum: 10/c03e0c5c5c5d22394c63948b35157b97f8f734a6a8403c89990c55b2657f2b284996aef8613815b2b576b271a126244d7f0a2c9ddece438c5799f273be2e1c69
   languageName: node
   linkType: hard
 
-"@polkadot/dev-ts@npm:^0.83.2":
-  version: 0.83.2
-  resolution: "@polkadot/dev-ts@npm:0.83.2"
+"@polkadot/dev-ts@npm:^0.83.3":
+  version: 0.83.3
+  resolution: "@polkadot/dev-ts@npm:0.83.3"
   dependencies:
     json5: "npm:^2.2.3"
     tslib: "npm:^2.7.0"
     typescript: "npm:^5.5.4"
-  checksum: 10/abca4df87a0682285bf5e5644ab8522820d53e0dffc124bfe540b7fccc55532057d1912629584bb04648e855e110896b36e55536d53556a166fc3d33bcc27b39
+  checksum: 10/a2ddc4dba934758cc24f02e8acbfa5a5f5295ad874f42c1bea8548a6dfa97c882b127a279001831caedc8d474becb905286847e0f64e8efe7063b6bac4830112
   languageName: node
   linkType: hard
 
-"@polkadot/dev@npm:^0.83.2":
-  version: 0.83.2
-  resolution: "@polkadot/dev@npm:0.83.2"
+"@polkadot/dev@npm:^0.83.3":
+  version: 0.83.3
+  resolution: "@polkadot/dev@npm:0.83.3"
   dependencies:
     "@eslint/js": "npm:^8.56.0"
-    "@polkadot/dev-test": "npm:^0.83.2"
-    "@polkadot/dev-ts": "npm:^0.83.2"
+    "@polkadot/dev-test": "npm:^0.83.3"
+    "@polkadot/dev-ts": "npm:^0.83.3"
     "@rollup/plugin-alias": "npm:^5.1.1"
     "@rollup/plugin-commonjs": "npm:^25.0.8"
     "@rollup/plugin-dynamic-import-vars": "npm:^2.1.5"
@@ -629,7 +657,7 @@ __metadata:
     polkadot-exec-rollup: scripts/polkadot-exec-rollup.mjs
     polkadot-exec-tsc: scripts/polkadot-exec-tsc.mjs
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.mjs
-  checksum: 10/42a67e0f2401fc13bdffff86398958e326613461eaa294fb5b435037d636b94cbbbce81b1fadbdf3c0553798d3bc5df43ef6af2250f75e312f01e52b665eddfe
+  checksum: 10/f34171f4776f0ade59e750e6c43db56fccc800e5c5c2e7796299e83072534257fa5e7478b8159a4b265e96d36c9fe380d56326c21cdbdf51dda3221c269601be
   languageName: node
   linkType: hard
 
@@ -637,11 +665,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/json-serve@workspace:packages/json-serve"
   dependencies:
-    "@polkadot/api": "npm:^16.1.2"
-    "@polkadot/api-augment": "npm:^16.1.2"
-    "@polkadot/api-derive": "npm:^16.1.2"
-    "@polkadot/types": "npm:^16.1.2"
-    "@polkadot/util": "npm:^13.5.1"
+    "@polkadot/api": "npm:^16.2.2"
+    "@polkadot/api-augment": "npm:^16.2.2"
+    "@polkadot/api-derive": "npm:^16.2.2"
+    "@polkadot/types": "npm:^16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
     "@types/koa": "npm:^2.13.12"
     "@types/koa-route": "npm:^3.2.8"
     "@types/node": "npm:^22.10.5"
@@ -673,11 +701,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/metadata-cmp@workspace:packages/metadata-cmp"
   dependencies:
-    "@polkadot/api": "npm:^16.1.2"
-    "@polkadot/api-augment": "npm:^16.1.2"
-    "@polkadot/keyring": "npm:^13.5.1"
-    "@polkadot/types": "npm:^16.1.2"
-    "@polkadot/util": "npm:^13.5.1"
+    "@polkadot/api": "npm:^16.2.2"
+    "@polkadot/api-augment": "npm:^16.2.2"
+    "@polkadot/keyring": "npm:^13.5.2"
+    "@polkadot/types": "npm:^16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
     "@types/node": "npm:^22.10.5"
     "@types/yargs": "npm:^17.0.33"
     tslib: "npm:^2.8.1"
@@ -691,9 +719,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/monitor-rpc@workspace:packages/monitor-rpc"
   dependencies:
-    "@polkadot/api": "npm:^16.1.2"
-    "@polkadot/types": "npm:^16.1.2"
-    "@polkadot/util": "npm:^13.5.1"
+    "@polkadot/api": "npm:^16.2.2"
+    "@polkadot/types": "npm:^16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
     "@types/koa": "npm:^2.13.12"
     "@types/koa-route": "npm:^3.2.8"
     "@types/node": "npm:^22.10.5"
@@ -731,6 +759,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/rpc-augment@npm:16.2.2":
+  version: 16.2.2
+  resolution: "@polkadot/rpc-augment@npm:16.2.2"
+  dependencies:
+    "@polkadot/rpc-core": "npm:16.2.2"
+    "@polkadot/types": "npm:16.2.2"
+    "@polkadot/types-codec": "npm:16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
+    tslib: "npm:^2.8.1"
+  checksum: 10/fba1891e9c3242e8b3f7322ad8a3887abe49cbd60313288df27846f67623de7c3d15d3104e79782b0c6ddb92e2e0c53e7418ec81190809677af7c18e14ca8dcf
+  languageName: node
+  linkType: hard
+
 "@polkadot/rpc-core@npm:16.1.2":
   version: 16.1.2
   resolution: "@polkadot/rpc-core@npm:16.1.2"
@@ -742,6 +783,20 @@ __metadata:
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
   checksum: 10/dbe435ecd121a01ba3f6d118d741b4ebd60075118f7bf2ce2c34f4df824a6bd02a10473c838356199438b4d6822d364d168164a66718fdd0e2fefc1795aa2744
+  languageName: node
+  linkType: hard
+
+"@polkadot/rpc-core@npm:16.2.2":
+  version: 16.2.2
+  resolution: "@polkadot/rpc-core@npm:16.2.2"
+  dependencies:
+    "@polkadot/rpc-augment": "npm:16.2.2"
+    "@polkadot/rpc-provider": "npm:16.2.2"
+    "@polkadot/types": "npm:16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
+    rxjs: "npm:^7.8.1"
+    tslib: "npm:^2.8.1"
+  checksum: 10/ffc4cda3a384a1ace46e67014cd2bbcbe7a12a71e2ea4084ee416bd485049266df4ce0174f3f61cd17b96f6b865ac75d0bf5fdb52410cb4747d1f03ebec6a7db
   languageName: node
   linkType: hard
 
@@ -769,16 +824,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/rpc-provider@npm:16.2.2":
+  version: 16.2.2
+  resolution: "@polkadot/rpc-provider@npm:16.2.2"
+  dependencies:
+    "@polkadot/keyring": "npm:^13.5.2"
+    "@polkadot/types": "npm:16.2.2"
+    "@polkadot/types-support": "npm:16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
+    "@polkadot/util-crypto": "npm:^13.5.2"
+    "@polkadot/x-fetch": "npm:^13.5.2"
+    "@polkadot/x-global": "npm:^13.5.2"
+    "@polkadot/x-ws": "npm:^13.5.2"
+    "@substrate/connect": "npm:0.8.11"
+    eventemitter3: "npm:^5.0.1"
+    mock-socket: "npm:^9.3.1"
+    nock: "npm:^13.5.5"
+    tslib: "npm:^2.8.1"
+  dependenciesMeta:
+    "@substrate/connect":
+      optional: true
+  checksum: 10/c851e9750867d83b3930db9ac7b24f5a7d34724e15e4fa384041eaa8e5791eb36bef3cd84784b0af6d01a061beaf8262e6629cc980d1a27f6706f08057c516fe
+  languageName: node
+  linkType: hard
+
 "@polkadot/signer-cli@workspace:packages/signer-cli":
   version: 0.0.0-use.local
   resolution: "@polkadot/signer-cli@workspace:packages/signer-cli"
   dependencies:
-    "@polkadot/api": "npm:^16.1.2"
+    "@polkadot/api": "npm:^16.2.2"
     "@polkadot/api-cli": "npm:^0.63.10-0-x"
-    "@polkadot/keyring": "npm:^13.5.1"
-    "@polkadot/types": "npm:^16.1.2"
-    "@polkadot/util": "npm:^13.5.1"
-    "@polkadot/util-crypto": "npm:^13.5.1"
+    "@polkadot/keyring": "npm:^13.5.2"
+    "@polkadot/types": "npm:^16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
+    "@polkadot/util-crypto": "npm:^13.5.2"
     "@types/node": "npm:^22.10.5"
     "@types/yargs": "npm:^17.0.33"
     tslib: "npm:^2.8.1"
@@ -800,6 +879,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/types-augment@npm:16.2.2":
+  version: 16.2.2
+  resolution: "@polkadot/types-augment@npm:16.2.2"
+  dependencies:
+    "@polkadot/types": "npm:16.2.2"
+    "@polkadot/types-codec": "npm:16.2.2"
+    "@polkadot/util": "npm:^13.5.2"
+    tslib: "npm:^2.8.1"
+  checksum: 10/0ca6b7cbf190b9da11d76d1ec847ef1bc388cc19a85e3b788430f3d9eb1abea52b9e5b65dbc5af9430c2eb6557e5809d133fac778a2758c0233ab6ea804dcb0d
+  languageName: node
+  linkType: hard
+
 "@polkadot/types-codec@npm:16.1.2":
   version: 16.1.2
   resolution: "@polkadot/types-codec@npm:16.1.2"
@@ -808,6 +899,17 @@ __metadata:
     "@polkadot/x-bigint": "npm:^13.5.1"
     tslib: "npm:^2.8.1"
   checksum: 10/384e97da54dc25d669742b1cac57ef2c7f64a34b768c8756d9669349aa15b365f8b3d8c3f9305299a3ff22b69e92aa2a08b9293be2c3f530b7ea2955dbdb5d34
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-codec@npm:16.2.2":
+  version: 16.2.2
+  resolution: "@polkadot/types-codec@npm:16.2.2"
+  dependencies:
+    "@polkadot/util": "npm:^13.5.2"
+    "@polkadot/x-bigint": "npm:^13.5.2"
+    tslib: "npm:^2.8.1"
+  checksum: 10/655d77fcbd1625c8fda4e83b51eca9378c2e1eaa557118603243bafb32e60bbc8fa7ecd95501f11dac9730d055bf2f115590675d8b323d508b02adfc584e7ea6
   languageName: node
   linkType: hard
 
@@ -843,6 +945,16 @@ __metadata:
     "@polkadot/util": "npm:^13.5.1"
     tslib: "npm:^2.8.1"
   checksum: 10/0f7157dc10b88a9f184359c28ffcb3983cd5e0bc50f117f8a9a187fdb9aca47b26dbef4e296ddd8bf6b5f1095cf156fcf9b8fd116abb2de5302ec6d1b0edf77d
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-support@npm:16.2.2":
+  version: 16.2.2
+  resolution: "@polkadot/types-support@npm:16.2.2"
+  dependencies:
+    "@polkadot/util": "npm:^13.5.2"
+    tslib: "npm:^2.8.1"
+  checksum: 10/f04c567f4f4ba686fbfefa5811324924bd39d4808ec43b66447e989569a16caf77c3ed60dc892aef03a2a958958460e8b2088e8568e35091d5dee2e63ecb53e7
   languageName: node
   linkType: hard
 
@@ -901,8 +1013,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/vanitygen@workspace:packages/vanitygen"
   dependencies:
-    "@polkadot/util": "npm:^13.5.1"
-    "@polkadot/util-crypto": "npm:^13.5.1"
+    "@polkadot/util": "npm:^13.5.2"
+    "@polkadot/util-crypto": "npm:^13.5.2"
     "@types/node": "npm:^22.10.5"
     "@types/yargs": "npm:^17.0.33"
     tslib: "npm:^2.8.1"
@@ -1002,6 +1114,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/x-bigint@npm:^13.5.2":
+  version: 13.5.2
+  resolution: "@polkadot/x-bigint@npm:13.5.2"
+  dependencies:
+    "@polkadot/x-global": "npm:13.5.2"
+    tslib: "npm:^2.8.0"
+  checksum: 10/1fdd3baa0e92f6917088ce7c89584d21bc0a54255f1f948ac0c2f35b4e653439a20f2c83ef0fbb049169d96871eead61f76324241cb092253afd15476075b307
+  languageName: node
+  linkType: hard
+
 "@polkadot/x-fetch@npm:^13.5.1":
   version: 13.5.1
   resolution: "@polkadot/x-fetch@npm:13.5.1"
@@ -1013,12 +1135,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/x-fetch@npm:^13.5.2":
+  version: 13.5.2
+  resolution: "@polkadot/x-fetch@npm:13.5.2"
+  dependencies:
+    "@polkadot/x-global": "npm:13.5.2"
+    node-fetch: "npm:^3.3.2"
+    tslib: "npm:^2.8.0"
+  checksum: 10/073886f45431b1c27e2ca9d8d32e81aa94383d990aa93638ec7e7ce0f0940ea556c373395776eee4302654cf40a69099f7de16f80fc5f6239e19fd6375d32b8d
+  languageName: node
+  linkType: hard
+
 "@polkadot/x-global@npm:13.5.1, @polkadot/x-global@npm:^13.5.1":
   version: 13.5.1
   resolution: "@polkadot/x-global@npm:13.5.1"
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10/6db58bbed5c6506c2f6d542cd836b242750a01d93e30fb6f19543a43ca7573a96813df44344df5d9ec938a913e2ddb8af0258f51770d3aa9f9bcbb896d8e5d1b
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-global@npm:13.5.2, @polkadot/x-global@npm:^13.5.2":
+  version: 13.5.2
+  resolution: "@polkadot/x-global@npm:13.5.2"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/619ae3952d8595f3c666030fa3880b68002a4d8706cd5fed3ef21d41c3e4ab4c1d08d2e31a92a7eee3950e82ef374c97f9713c381209ae769021b286a29312df
   languageName: node
   linkType: hard
 
@@ -1063,6 +1205,17 @@ __metadata:
     tslib: "npm:^2.8.0"
     ws: "npm:^8.18.0"
   checksum: 10/7c4f5d9178efb663b03303053f2e83bec2fc87ad29306116237549eb004d8f64a945570da966ddab99657db6499fc6056c51daf11dff62095a701c9fb231eb2a
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-ws@npm:^13.5.2":
+  version: 13.5.2
+  resolution: "@polkadot/x-ws@npm:13.5.2"
+  dependencies:
+    "@polkadot/x-global": "npm:13.5.2"
+    tslib: "npm:^2.8.0"
+    ws: "npm:^8.18.0"
+  checksum: 10/eb1a8af0f17d80a861e5b0142f0d2f092a49eadd09f1c9ec471c22c1e9f690b51e3edea110dcf1240649eaf71805b39c9f68812bba3e3450db59a94d8e96cd7b
   languageName: node
   linkType: hard
 
@@ -8266,7 +8419,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@polkadot/dev": "npm:^0.83.2"
+    "@polkadot/dev": "npm:^0.83.3"
     "@types/node": "npm:^22.10.5"
     "@types/yargs": "npm:^17.0.33"
   languageName: unknown


### PR DESCRIPTION
## Description
```
   @polkadot/api-augment ----------------------- ◯ ^16.1.2 ------ ◉ ^16.2.2 ------
   @polkadot/api-derive ------------------------ ◯ ^16.1.2 ------ ◉ ^16.2.2 ------
   @polkadot/api ------------------------------- ◯ ^16.1.2 ------ ◉ ^16.2.2 ------
   @polkadot/dev ------------------------------- ◯ ^0.83.2 ------ ◉ ^0.83.3 ------
   @polkadot/keyring --------------------------- ◯ ^13.5.1 ------ ◉ ^13.5.2 ------
   @polkadot/types ----------------------------- ◯ ^16.1.2 ------ ◉ ^16.2.2 ------
   @polkadot/util-crypto ----------------------- ◯ ^13.5.1 ------ ◉ ^13.5.2 ------
   @polkadot/util ------------------------------ ◯ ^13.5.1 ------ ◉ ^13.5.2 ------
```