### PR TITLE
Bump polkadot deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "@types/yargs": "^17.0.33"
   },
   "resolutions": {
-    "@polkadot/api": "^16.4.6",
-    "@polkadot/api-derive": "^16.4.6",
+    "@polkadot/api": "^16.4.8",
+    "@polkadot/api-derive": "^16.4.8",
     "@polkadot/keyring": "^13.5.6",
-    "@polkadot/types": "^16.4.6",
+    "@polkadot/types": "^16.4.8",
     "@polkadot/util": "^13.5.6",
     "@polkadot/util-crypto": "^13.5.6",
     "typescript": "^5.5.4"

--- a/packages/api-cli/package.json
+++ b/packages/api-cli/package.json
@@ -21,10 +21,10 @@
     "polkadot-js-api": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.4.6",
-    "@polkadot/api-augment": "^16.4.6",
+    "@polkadot/api": "^16.4.8",
+    "@polkadot/api-augment": "^16.4.8",
     "@polkadot/keyring": "^13.5.6",
-    "@polkadot/types": "^16.4.6",
+    "@polkadot/types": "^16.4.8",
     "@polkadot/util": "^13.5.6",
     "@polkadot/util-crypto": "^13.5.6",
     "tslib": "^2.8.1",

--- a/packages/json-serve/package.json
+++ b/packages/json-serve/package.json
@@ -21,10 +21,10 @@
     "polkadot-js-json-serve": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.4.6",
-    "@polkadot/api-augment": "^16.4.6",
-    "@polkadot/api-derive": "^16.4.6",
-    "@polkadot/types": "^16.4.6",
+    "@polkadot/api": "^16.4.8",
+    "@polkadot/api-augment": "^16.4.8",
+    "@polkadot/api-derive": "^16.4.8",
+    "@polkadot/types": "^16.4.8",
     "@polkadot/util": "^13.5.6",
     "koa": "^2.14.2",
     "koa-route": "^3.2.0",

--- a/packages/metadata-cmp/package.json
+++ b/packages/metadata-cmp/package.json
@@ -21,10 +21,10 @@
     "polkadot-js-metadata-cmp": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.4.6",
-    "@polkadot/api-augment": "^16.4.6",
+    "@polkadot/api": "^16.4.8",
+    "@polkadot/api-augment": "^16.4.8",
     "@polkadot/keyring": "^13.5.6",
-    "@polkadot/types": "^16.4.6",
+    "@polkadot/types": "^16.4.8",
     "@polkadot/util": "^13.5.6",
     "tslib": "^2.8.1",
     "yargs": "^17.7.2"

--- a/packages/monitor-rpc/package.json
+++ b/packages/monitor-rpc/package.json
@@ -21,8 +21,8 @@
     "polkadot-js-monitor": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.4.6",
-    "@polkadot/types": "^16.4.6",
+    "@polkadot/api": "^16.4.8",
+    "@polkadot/types": "^16.4.8",
     "@polkadot/util": "^13.5.6",
     "koa": "^2.14.2",
     "koa-route": "^3.2.0",

--- a/packages/signer-cli/package.json
+++ b/packages/signer-cli/package.json
@@ -21,10 +21,10 @@
     "polkadot-js-signer": "./runcli.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "^16.4.6",
+    "@polkadot/api": "^16.4.8",
     "@polkadot/api-cli": "^0.63.15",
     "@polkadot/keyring": "^13.5.6",
-    "@polkadot/types": "^16.4.6",
+    "@polkadot/types": "^16.4.8",
     "@polkadot/util": "^13.5.6",
     "@polkadot/util-crypto": "^13.5.6",
     "tslib": "^2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,31 +606,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:16.4.6, @polkadot/api-augment@npm:^16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/api-augment@npm:16.4.6"
+"@polkadot/api-augment@npm:16.4.8, @polkadot/api-augment@npm:^16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/api-augment@npm:16.4.8"
   dependencies:
-    "@polkadot/api-base": "npm:16.4.6"
-    "@polkadot/rpc-augment": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-augment": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
+    "@polkadot/api-base": "npm:16.4.8"
+    "@polkadot/rpc-augment": "npm:16.4.8"
+    "@polkadot/types": "npm:16.4.8"
+    "@polkadot/types-augment": "npm:16.4.8"
+    "@polkadot/types-codec": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     tslib: "npm:^2.8.1"
-  checksum: 10/eeac05b87873e2abb86aead4c9003ce56cdf3ba33e496b569d71bc6cc62112100a080639f4da4adfd077fd2c3d5e098c0e538b69471a0a877a83c4440d72a922
+  checksum: 10/9cfcaedff7777b5b15aa6490150df6b54e0d7b719696629897f0ba5ebd050b74e5930d4493b4b642a944720510d744668f2fdfcc36a2636c87999a1906d2c821
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/api-base@npm:16.4.6"
+"@polkadot/api-base@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/api-base@npm:16.4.8"
   dependencies:
-    "@polkadot/rpc-core": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
+    "@polkadot/rpc-core": "npm:16.4.8"
+    "@polkadot/types": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/29f190545e73b8def9185a37486c97b4146e5a44ee7826f7f6bc658023ca336563b08703da5863bf2a06291c302f5ee9f640f09faed0fade995b48ca5787d738
+  checksum: 10/017aeaa73dc32c89f9e21ef03f8c207ab5e683566cc18c834d35b2212df2e94bc814c7d3c60ffbff06699346ffac3e681f735255d76196d35eda3e23831324a9
   languageName: node
   linkType: hard
 
@@ -638,10 +638,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/api-cli@workspace:packages/api-cli"
   dependencies:
-    "@polkadot/api": "npm:^16.4.6"
-    "@polkadot/api-augment": "npm:^16.4.6"
+    "@polkadot/api": "npm:^16.4.8"
+    "@polkadot/api-augment": "npm:^16.4.8"
     "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/types": "npm:^16.4.6"
+    "@polkadot/types": "npm:^16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@polkadot/util-crypto": "npm:^13.5.6"
     "@types/node": "npm:^22.10.5"
@@ -653,46 +653,46 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/api-derive@npm:^16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/api-derive@npm:16.4.6"
+"@polkadot/api-derive@npm:^16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/api-derive@npm:16.4.8"
   dependencies:
-    "@polkadot/api": "npm:16.4.6"
-    "@polkadot/api-augment": "npm:16.4.6"
-    "@polkadot/api-base": "npm:16.4.6"
-    "@polkadot/rpc-core": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
+    "@polkadot/api": "npm:16.4.8"
+    "@polkadot/api-augment": "npm:16.4.8"
+    "@polkadot/api-base": "npm:16.4.8"
+    "@polkadot/rpc-core": "npm:16.4.8"
+    "@polkadot/types": "npm:16.4.8"
+    "@polkadot/types-codec": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@polkadot/util-crypto": "npm:^13.5.6"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/677475de15d1a38af57fea144f1cabcde522bc3d3abe6652ba9fd6e7c788197b08fd8774fda1991d6ff51ffa88398f6acb0974bd0eaf1b57293609357383309f
+  checksum: 10/6e5aaafbbb248419a167a6f5e74a351214329a85b8d882ed9d2142699b6d5a986af73956d6cf5761ece3609f6ac2e8f87cdbfae9d2c9437cbb4c28b013ed3c2d
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:^16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/api@npm:16.4.6"
+"@polkadot/api@npm:^16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/api@npm:16.4.8"
   dependencies:
-    "@polkadot/api-augment": "npm:16.4.6"
-    "@polkadot/api-base": "npm:16.4.6"
-    "@polkadot/api-derive": "npm:16.4.6"
+    "@polkadot/api-augment": "npm:16.4.8"
+    "@polkadot/api-base": "npm:16.4.8"
+    "@polkadot/api-derive": "npm:16.4.8"
     "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/rpc-augment": "npm:16.4.6"
-    "@polkadot/rpc-core": "npm:16.4.6"
-    "@polkadot/rpc-provider": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-augment": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/types-create": "npm:16.4.6"
-    "@polkadot/types-known": "npm:16.4.6"
+    "@polkadot/rpc-augment": "npm:16.4.8"
+    "@polkadot/rpc-core": "npm:16.4.8"
+    "@polkadot/rpc-provider": "npm:16.4.8"
+    "@polkadot/types": "npm:16.4.8"
+    "@polkadot/types-augment": "npm:16.4.8"
+    "@polkadot/types-codec": "npm:16.4.8"
+    "@polkadot/types-create": "npm:16.4.8"
+    "@polkadot/types-known": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@polkadot/util-crypto": "npm:^13.5.6"
     eventemitter3: "npm:^5.0.1"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/d5391f9bf21c3d6e27e640a03e1ab44c26e6ce9362abc6e2921533604374ba871b4c6891ea2c148e62a9753eed9700dc73de2ed72d31d1735c6ae67efe8f5aef
+  checksum: 10/e89d485508523b82c05971d8ef976a6b7b0723743668554fb0f3f4f50c000de05bc0214dcaa03be6d0043224885313e7e4234fa9059dd4fd855e3c7f9c9c229c
   languageName: node
   linkType: hard
 
@@ -796,10 +796,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/json-serve@workspace:packages/json-serve"
   dependencies:
-    "@polkadot/api": "npm:^16.4.6"
-    "@polkadot/api-augment": "npm:^16.4.6"
-    "@polkadot/api-derive": "npm:^16.4.6"
-    "@polkadot/types": "npm:^16.4.6"
+    "@polkadot/api": "npm:^16.4.8"
+    "@polkadot/api-augment": "npm:^16.4.8"
+    "@polkadot/api-derive": "npm:^16.4.8"
+    "@polkadot/types": "npm:^16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@types/koa": "npm:^2.13.12"
     "@types/koa-route": "npm:^3.2.8"
@@ -832,10 +832,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/metadata-cmp@workspace:packages/metadata-cmp"
   dependencies:
-    "@polkadot/api": "npm:^16.4.6"
-    "@polkadot/api-augment": "npm:^16.4.6"
+    "@polkadot/api": "npm:^16.4.8"
+    "@polkadot/api-augment": "npm:^16.4.8"
     "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/types": "npm:^16.4.6"
+    "@polkadot/types": "npm:^16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@types/node": "npm:^22.10.5"
     "@types/yargs": "npm:^17.0.33"
@@ -850,8 +850,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/monitor-rpc@workspace:packages/monitor-rpc"
   dependencies:
-    "@polkadot/api": "npm:^16.4.6"
-    "@polkadot/types": "npm:^16.4.6"
+    "@polkadot/api": "npm:^16.4.8"
+    "@polkadot/types": "npm:^16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@types/koa": "npm:^2.13.12"
     "@types/koa-route": "npm:^3.2.8"
@@ -877,40 +877,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/rpc-augment@npm:16.4.6"
+"@polkadot/rpc-augment@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/rpc-augment@npm:16.4.8"
   dependencies:
-    "@polkadot/rpc-core": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
+    "@polkadot/rpc-core": "npm:16.4.8"
+    "@polkadot/types": "npm:16.4.8"
+    "@polkadot/types-codec": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     tslib: "npm:^2.8.1"
-  checksum: 10/ef2559b4807bc8340f5ec14725924fe5a4946c387b05c73f3c7353297a5487e55f1027d659bea4b3dacb3b8d3c5f578a06d541722fba3a712caac08a7a3d61f4
+  checksum: 10/bcc2f83023d479cb521843e44d00789461cf77ad1f9a31117717ebc4a913d702ded579daa07b49216988b511875da18d866338b8b91bee9fa6d20c1c7d587b48
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/rpc-core@npm:16.4.6"
+"@polkadot/rpc-core@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/rpc-core@npm:16.4.8"
   dependencies:
-    "@polkadot/rpc-augment": "npm:16.4.6"
-    "@polkadot/rpc-provider": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
+    "@polkadot/rpc-augment": "npm:16.4.8"
+    "@polkadot/rpc-provider": "npm:16.4.8"
+    "@polkadot/types": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/b0d6afcb389b335ada3d5306463dad6fb79985bccd2bca541de422ceb537ed576ea876529560f06693be095e4fd5db3fda07723da0e6105d40b0427540e4b8e4
+  checksum: 10/a38763b7612a72d31781139fc5914470b40eba6314593e1cbf7d7b980734e7ee90f346a2838ab39288992a88bd4dd610b02d6975415ee4fbb23a3a12761fd30c
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/rpc-provider@npm:16.4.6"
+"@polkadot/rpc-provider@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/rpc-provider@npm:16.4.8"
   dependencies:
     "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-support": "npm:16.4.6"
+    "@polkadot/types": "npm:16.4.8"
+    "@polkadot/types-support": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@polkadot/util-crypto": "npm:^13.5.6"
     "@polkadot/x-fetch": "npm:^13.5.6"
@@ -924,7 +924,7 @@ __metadata:
   dependenciesMeta:
     "@substrate/connect":
       optional: true
-  checksum: 10/7e90de9be86f866359dddbab7bb2b814f1bc705d7420e0e23aecbe19a42b283938e1113a3fe81b13c4f6b0963f27384a6f4318d3a761ce796cdfa428cd3a41d7
+  checksum: 10/62a0ec5bb1c046cc0f6c0b813232c6498f58356af40f11a6af8d611ec096de451db94a39590491da139d4f095522cd35c12c4606486507f685ea4a36b37a970e
   languageName: node
   linkType: hard
 
@@ -932,10 +932,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/signer-cli@workspace:packages/signer-cli"
   dependencies:
-    "@polkadot/api": "npm:^16.4.6"
+    "@polkadot/api": "npm:^16.4.8"
     "@polkadot/api-cli": "npm:^0.63.15"
     "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/types": "npm:^16.4.6"
+    "@polkadot/types": "npm:^16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@polkadot/util-crypto": "npm:^13.5.6"
     "@types/node": "npm:^22.10.5"
@@ -947,77 +947,77 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/types-augment@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-augment@npm:16.4.6"
+"@polkadot/types-augment@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/types-augment@npm:16.4.8"
   dependencies:
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
+    "@polkadot/types": "npm:16.4.8"
+    "@polkadot/types-codec": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     tslib: "npm:^2.8.1"
-  checksum: 10/c8c7b8065a0b11de05eaf62550ca87e3423455fd8c345ce4e547f99337ff1634508716ce397fb68d7c038b265ac82d07c7860fb69212f3df1c15e02dcc876844
+  checksum: 10/891378160780e4b2288a83326a73adcdf6b3f66e4e290c3afb0dd8e1d420f47d782f7c96c07a5d627dd82a2e92b1da3867991be782ffa0a29c42d3be5a7f1b1f
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-codec@npm:16.4.6"
+"@polkadot/types-codec@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/types-codec@npm:16.4.8"
   dependencies:
     "@polkadot/util": "npm:^13.5.6"
     "@polkadot/x-bigint": "npm:^13.5.6"
     tslib: "npm:^2.8.1"
-  checksum: 10/73a728a5da522188a1aa8d9a241a9445d6dbdc116323ce5f0a7a83f8c355c84a6f12ce2a37c60d706b9e3f1cab63f39dcbfb8dc80ba8ffd8558b55ca004c9e8e
+  checksum: 10/d8e755e75e795992eebb126fd618fa2b0a825efca654c9dbaab4560b38d4e90cb70ab7f39a42deeb4b7f7632caf5277feb5cc9cac743f9aff146b5af0ec34e64
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-create@npm:16.4.6"
+"@polkadot/types-create@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/types-create@npm:16.4.8"
   dependencies:
-    "@polkadot/types-codec": "npm:16.4.6"
+    "@polkadot/types-codec": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     tslib: "npm:^2.8.1"
-  checksum: 10/a47c6f7b9895f1864ccec134c710bd593e1662faf85172e1e606f6e8946a130879fd1e2b842d9de8a2ded87665fef9fe08decac19813402e71179c70040edc6f
+  checksum: 10/c0edb037abc924856e707f178cf35fb24a6e30577dfce163b6ab4bab1a5cd9f0de400a45b3388c6b4612993832696b321122b5a9fdeeb5c8600bbcf2eed3b6c5
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-known@npm:16.4.6"
+"@polkadot/types-known@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/types-known@npm:16.4.8"
   dependencies:
     "@polkadot/networks": "npm:^13.5.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/types-create": "npm:16.4.6"
+    "@polkadot/types": "npm:16.4.8"
+    "@polkadot/types-codec": "npm:16.4.8"
+    "@polkadot/types-create": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     tslib: "npm:^2.8.1"
-  checksum: 10/f512322c76883a8c3fab4050fd986ad90a68152d912598db391313934680097eaa20e81055c6fb0a7a7bd7834b0943335859465dc19b843febec8ba30cb9cc3d
+  checksum: 10/e2feae233e76cf5838162e1d9ec3e085a8c86bdf91f6fba92439125b60d3bf04b181cea3a3b99117a3ff5b1f9c4f11334ca72022ffa736292df6dedec62b21d4
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-support@npm:16.4.6"
+"@polkadot/types-support@npm:16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/types-support@npm:16.4.8"
   dependencies:
     "@polkadot/util": "npm:^13.5.6"
     tslib: "npm:^2.8.1"
-  checksum: 10/d6cc870ab18f2cad098e3677903004ce31fa135ad214ad287ff90d6546666235eafbe0ae619e5bd420ee6e9ca7cd60c6819aa55f30fbc25bd4a2f9e470f15a0e
+  checksum: 10/6e65d55acf7a9a40d95c76076bb615889c321caffd8d442d4d68e09a563526328dbd2ee53ddcd3d90b7f37928e77d6332dbbfeed0982061e922ba0f28c6cd2c2
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:^16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types@npm:16.4.6"
+"@polkadot/types@npm:^16.4.8":
+  version: 16.4.8
+  resolution: "@polkadot/types@npm:16.4.8"
   dependencies:
     "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/types-augment": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/types-create": "npm:16.4.6"
+    "@polkadot/types-augment": "npm:16.4.8"
+    "@polkadot/types-codec": "npm:16.4.8"
+    "@polkadot/types-create": "npm:16.4.8"
     "@polkadot/util": "npm:^13.5.6"
     "@polkadot/util-crypto": "npm:^13.5.6"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/1a02ff3733f665147cbfa6016a74a2392c5c2883fc13743627f49bfd886cacd3caee5966b287b35a1bde7f02198248650ea38cf28bb651cef15d9cc38388a96b
+  checksum: 10/1a6bc869f1f592f904011cb18c917fc7874a2222e1232e431b2fdf5e43bf9e0ec5ad9a159f602355955f56ff1f20448e1db2e0a4a4a2768d1e9be3c4d99ac42c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📝 Description

This PR aims to bump polkadot dependencies.

```
   @polkadot/api-augment ----------------------- ◯ ^16.4.6 ------ ◉ ^16.4.8 ------
   @polkadot/api-derive ------------------------ ◯ ^16.4.6 ------ ◉ ^16.4.8 ------
   @polkadot/api ------------------------------- ◯ ^16.4.6 ------ ◉ ^16.4.8 ------
   @polkadot/types ----------------------------- ◯ ^16.4.6 ------ ◉ ^16.4.8 ------
```